### PR TITLE
Update espn_teamnicknames.json

### DIFF
--- a/espn_teamnicknames.json
+++ b/espn_teamnicknames.json
@@ -94,7 +94,8 @@
     "cincinatti",
     "cincy",
     "cinci",
-    "cinc"
+    "cinc",
+    "cincinnati"
   ],
   "Clemson": [
     "fuck",
@@ -410,7 +411,7 @@
     "san jose",
     "san jose state",
     "san jose st",
-    "san josé state"
+    "san josÃ© state"
   ],
   "SMU": [
     "southern methodist",


### PR DESCRIPTION
the actual correct spelling of cincinnati was not in the list. Added.